### PR TITLE
sqlite: use 0 instead of FALSE

### DIFF
--- a/src/sqltrie/sqlite/init.sql
+++ b/src/sqltrie/sqlite/init.sql
@@ -11,4 +11,4 @@ CREATE TABLE IF NOT EXISTS nodes (
 );
 CREATE INDEX IF NOT EXISTS nodes_pid_idx ON nodes (pid);
 INSERT OR IGNORE INTO nodes (id, pid, name, has_value, value)
-VALUES (1, NULL, "", FALSE, NULL);
+VALUES (1, NULL, "", 0, NULL);


### PR DESCRIPTION
TRUE/FALSE became available in version 3.23.0 (2018-04-02), but apparently it is still pretty widespread.