### PR TITLE
_traverse: Escape single quotes in `path`.

### DIFF
--- a/src/sqltrie/sqlite/sqlite.py
+++ b/src/sqltrie/sqlite/sqlite.py
@@ -117,9 +117,8 @@ class SQLiteTrie(AbstractTrie):
         return pid
 
     def _traverse(self, key):
-        self._conn.executescript(
-            STEPS_SQL.format(path="/".join(key), root=self._root_id)
-        )
+        path = "/".join(key).replace("'", "''")
+        self._conn.executescript(STEPS_SQL.format(path=path, root=self._root_id))
 
         return self._conn.execute(f"SELECT * FROM {STEPS_TABLE}").fetchall()  # nosec
 

--- a/tests/test_sqltrie.py
+++ b/tests/test_sqltrie.py
@@ -98,6 +98,9 @@ def test_set_get(cls):
     assert trie[("foo",)] == b"2"
     assert trie[("foo", "bar")] == b"1"
 
+    trie[("foo'bar",)] = b"2"
+    assert trie[("foo'bar",)] == b"2"
+
 
 @pytest.mark.parametrize("cls", [SQLiteTrie, PyGTrie])
 def test_has_node(cls):


### PR DESCRIPTION
Per https://github.com/iterative/dvc/issues/9539