### PR TITLE
fix(sqlite): bool constants available since 3.23 while 3.8 is min req

### DIFF
--- a/src/sqltrie/sqlite/sqlite.py
+++ b/src/sqltrie/sqlite/sqlite.py
@@ -217,7 +217,9 @@ class SQLiteTrie(AbstractTrie):
         )
 
     def __len__(self):
-        self._conn.executescript(ITEMS_SQL.format(root=self._root_id, shallow=False))
+        self._conn.executescript(
+            ITEMS_SQL.format(root=self._root_id, shallow=int(False))
+        )
         return self._conn.execute(  # nosec
             f"""
             SELECT COUNT(*) AS count FROM {ITEMS_TABLE}
@@ -274,7 +276,7 @@ class SQLiteTrie(AbstractTrie):
         if has_value:
             yield prefix, value
 
-        self._conn.executescript(ITEMS_SQL.format(root=pid, shallow=shallow))
+        self._conn.executescript(ITEMS_SQL.format(root=pid, shallow=int(shallow)))
         rows = self._conn.execute(f"SELECT * FROM {ITEMS_TABLE}")  # nosec
 
         yield from (((*prefix, *row["path"].split("/")), row["value"]) for row in rows)
@@ -329,7 +331,7 @@ class SQLiteTrie(AbstractTrie):
             DIFF_SQL.format(
                 old_root=old_id,
                 new_root=new_id,
-                with_unchanged=with_unchanged,
+                with_unchanged=int(with_unchanged),
             )
         )
 

--- a/tests/test_sqltrie.py
+++ b/tests/test_sqltrie.py
@@ -110,7 +110,7 @@ def test_set_get_root(cls):
     assert trie[()] == b"root"
     del trie[()]
     with pytest.raises(KeyError):
-        trie[()]
+        trie[()]  # pylint: disable=pointless-statement
 
 
 @pytest.mark.parametrize("cls", [SQLiteTrie, PyGTrie])


### PR DESCRIPTION
Come from the support ticket with symptoms like:

```python
  File "/home/ec2-user/actions-runner/_work/****/venv/lib/python3.9/site-packages/dvc_data/index/index.py", line 663, in iteritems
    for key, entry in self._trie.items(**kwargs):
  File "/home/ec2-user/actions-runner/_work/****/venv/lib/python3.9/site-packages/sqltrie/serialized.py", line 78, in items
    yield from (
  File "/home/ec2-user/actions-runner/_work/*****/venv/lib/python3.9/site-packages/sqltrie/serialized.py", line 78, in <genexpr>
    yield from (
  File "/home/ec2-user/actions-runner/_work/*****/venv/lib/python3.9/site-packages/sqltrie/sqlite/sqlite.py", line 277, in items
    self._conn.executescript(ITEMS_SQL.format(root=pid, shallow=shallow))
sqlite3.OperationalError: no such column: False
```
 
DVC version:

```
DVC version: 3.0.0 (pip)
------------------------
Platform: Python 3.9.6 on Linux-4.14.173-137.229.amzn2.x86_64-x86_64-with-glibc2.26
Subprojects:
              dvc_data = 1.11.0
              dvc_objects = 0.23.0
              dvc_render = 0.5.3
              dvc_task = 0.3.0
              scmrepo = 1.0.3
Supports:
              http (aiohttp = 3.8.4, aiohttp-retry = 2.8.3),
              https (aiohttp = 3.8.4, aiohttp-retry = 2.8.3),
              s3 (s3fs = 2023.6.0, boto3 = 1.26.76)
Config:
              Global: /home/ec2-user/.config/dvc
              System: /etc/xdg/dvc
Cache types: https://error.dvc.org/no-dvc-cache
Caches: local
Remotes: s3
Workspace directory: xfs on /dev/xvda1
Repo: dvc, git
Repo.site_cache_dir: /var/tmp/dvc/repo/*****
```

It means that it's EC2 instance, with AMZ AMI which usually has a very old version of SQLite.

Boolean constants are supported only since [3.23](https://www.sqlite.org/releaselog/3_23_0.html).

Not sure if there are other limitations there and if everything actually works on 3.8.3 (ideally we should be testing against it on CI - build it from sources if needed and test or make the threshold bigger).