### PR TITLE
SQLiteTrie: use pygtrie for in memory traversal

### DIFF
--- a/src/sqltrie/serialized.py
+++ b/src/sqltrie/serialized.py
@@ -88,8 +88,10 @@ class SerializedTrie(AbstractTrie):
             yield from entries
 
     def traverse(self, node_factory, prefix=None):
-        def _node_factory_wrapper(path_conv, path, children, value):
-            return node_factory(path_conv, path, children, self._load(path, value))
+        def _node_factory_wrapper(path_conv, path, children, *value):
+            return node_factory(
+                path_conv, path, children, self._load(path, value[0] if value else None)
+            )
 
         return self._trie.traverse(_node_factory_wrapper, prefix=prefix)
 


### PR DESCRIPTION
Should fix https://github.com/iterative/dvc/issues/9914

After looking at this some more we can just simplify it to use an in-memory trie specifically for traversal, and leave everything else as-is (so all other view operations still reflect the live db)

DVC main with this PR
```
+ dvc push
24972 files pushed

real    0m7.030s
user    0m2.331s
sys     0m3.188s

+ dvc pull
A       cats_dogs/
1 file added and 24972 files fetched

real    0m15.335s
user    0m4.940s
sys     0m6.977s
```

DVC main without PR:
```
+ dvc push
24972 files pushed

real    0m6.914s
user    0m2.330s
sys     0m3.151s

+ dvc pull
A       cats_dogs/
1 file added and 24972 files fetched

real    1m46.046s
user    1m24.086s
sys     0m18.272s
```

DVC 3.10
```
+ dvc push
24972 files pushed

real    0m6.164s
user    0m1.616s
sys     0m2.998s

+ dvc pull
A       cats_dogs/
1 file added and 24972 files fetched

real    0m15.515s
user    0m5.079s
sys     0m7.013s
```