### PR TITLE
add support for 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ['3.8', '3.9', '3.10', '3.11']
+        pyv: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Check out the repository

--- a/src/sqltrie/sqlite/sqlite.py
+++ b/src/sqltrie/sqlite/sqlite.py
@@ -234,14 +234,10 @@ class SQLiteTrie(AbstractTrie):
                 """
                 INSERT INTO
                     nodes (pid, name, has_value, value)
-                    VALUES (?1, ?2, True, ?3)
-                    ON CONFLICT (pid, name) DO UPDATE SET has_value=True, value=?3
+                    VALUES (:pid, :name, True, :value)
+                    ON CONFLICT (pid, name) DO UPDATE SET has_value=True, value=:value
                 """,
-                (
-                    pid,
-                    key[-1],
-                    value,
-                ),
+                {"pid": pid, "name": key[-1], "value": value},
             )
         else:
             self._conn.execute(
@@ -250,19 +246,15 @@ class SQLiteTrie(AbstractTrie):
                     nodes (id, pid, name, has_value, value)
                     SELECT
                         COALESCE(
-                            (SELECT id FROM nodes WHERE pid == ?1 AND name == ?2),
+                            (SELECT id FROM nodes WHERE pid == :pid AND name == :name),
                             (SELECT MAX(id) + 1 FROM nodes)
                         ),
-                        ?1,
-                        ?2,
+                        :pid,
+                        :name,
                         1,
-                        ?3
+                        :value
                 """,
-                (
-                    pid,
-                    key[-1],
-                    value,
-                ),
+                {"pid": pid, "name": key[-1], "value": value},
             )
 
     def __iter__(self):


### PR DESCRIPTION
> DeprecationWarning is now emitted when named placeholders are used together with parameters supplied as a sequence instead of as a dict. Starting from Python 3.14, using named placeholders with parameters supplied as a sequence will raise a ProgrammingError.


See https://github.com/python/cpython/issues/101693, and discussion on https://discuss.python.org/t/sqlite3-consider-deprecating-combining-named-placeholders-with-sequence-of-params/22450.