### PR TITLE
replace hash with unsafe_hash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    "attrs",
+    "attrs>=22.2.0",
     # NOTE: orjson doesn't support pypy, see
     # https://github.com/ijl/orjson/issues/90
     "orjson; implementation_name=='cpython'",

--- a/src/sqltrie/trie.py
+++ b/src/sqltrie/trie.py
@@ -50,7 +50,7 @@ DELETE = "delete"
 UNCHANGED = "unchanged"
 
 
-@define(frozen=True, hash=True, order=True)
+@define(frozen=True, unsafe_hash=True, order=True)
 class Change:
     typ: str
     old: Optional[TrieNode]


### PR DESCRIPTION
It was added in 22.2.0, and is an alias to `hash`. The `hash` is deprecated since the latest release 24.1.0.